### PR TITLE
[OPS] Add a workflow to remove SNAPSHOT suffix when create a release PR

### DIFF
--- a/.github/workflows/remove-snapshot.yml
+++ b/.github/workflows/remove-snapshot.yml
@@ -1,0 +1,24 @@
+name: Remove SNAPSHOT suffix
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  remove-snapshot-suffix:
+    if: "${{ startsWith(github.event.pull_request.title, '[RELEASE]')}}"
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove SNAPSHOT suffix
+        uses: lllIIIIlll/actions/maven-remove-snapshot-suffix@main
+        with:
+          nexus-user: ${{ secrets.NEXUS_USERNAME }}
+          nexus-password: ${{ secrets.NEXUS_PASSWORD }}
+          includes-dependencies: net.ow.shared:*


### PR DESCRIPTION
## Description

- Add a workflow to remove SNAPSHOT suffix when create a release PR

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

