### PR TITLE
[OPS] Add a workflow to do automate release when a release PR is merged to main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release pull request
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+env:
+  PR_TITLE: ${{ github.event.pull_request.title }}
+  PR_BODY: ${{ github.event.pull_request.body }}
+
+jobs:
+  release-pr:
+    if: "${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[RELEASE]') }}"
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Set variables"
+        run: |
+          RELEASE_VERSION=`echo ${PR_TITLE} | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1`
+          RELEASE_TITLE=`echo ${PR_TITLE/release: /}`
+
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
+          echo "RELEASE_TITLE=${RELEASE_TITLE}" >> "$GITHUB_ENV"
+
+      - name: "Create release"
+        run: gh release create ${RELEASE_VERSION} -t "${RELEASE_TITLE}" -n "${PR_BODY}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

- Add a workflow to do automate release when a release PR is merged to main branch

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [ ] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

