### PR TITLE
[RFT] Refactor ImagePathSerializer and ImagePathDeserializer

### DIFF
--- a/src/main/java/net/ow/movie/tmdb/deserializer/ImagePathDeserializer.java
+++ b/src/main/java/net/ow/movie/tmdb/deserializer/ImagePathDeserializer.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import java.io.IOException;
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Value;
 
 public class ImagePathDeserializer extends JsonDeserializer<String> {

--- a/src/main/java/net/ow/movie/tmdb/deserializer/ImagePathDeserializer.java
+++ b/src/main/java/net/ow/movie/tmdb/deserializer/ImagePathDeserializer.java
@@ -9,19 +9,22 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class ImagePathDeserializer extends JsonDeserializer<String> {
     @Value("${tmdb.image.url}")
-    private String imageUrl;
+    private String imageURL;
 
     @Value("${tmdb.image.size}")
     private String imageSize;
+
+    @Value("${tmdb.image.not-found}")
+    private String notFoundImageURL;
 
     @Override
     public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException {
         String text = jsonParser.getText();
         if (null == text || text.isBlank()) {
-            return Strings.EMPTY;
+            return notFoundImageURL;
         }
 
-        return imageUrl + "/" + imageSize + text;
+        return imageURL + "/" + imageSize + text;
     }
 }

--- a/src/main/java/net/ow/movie/tmdb/serializer/ImagePathSerializer.java
+++ b/src/main/java/net/ow/movie/tmdb/serializer/ImagePathSerializer.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
-
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Value;
 

--- a/src/main/java/net/ow/movie/tmdb/serializer/ImagePathSerializer.java
+++ b/src/main/java/net/ow/movie/tmdb/serializer/ImagePathSerializer.java
@@ -4,24 +4,34 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
+
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Value;
 
 public class ImagePathSerializer extends JsonSerializer<String> {
     @Value("${tmdb.image.url}")
-    private String imageUrl;
+    private String imageURL;
 
     @Value("${tmdb.image.size}")
     private String imageSize;
+
+    @Value("${tmdb.image.not-found}")
+    private String notFoundImageURL;
 
     @Override
     public void serialize(
             String posterPath, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
             throws IOException {
         if (null == posterPath || posterPath.isBlank()) {
-            jsonGenerator.writeString("");
+            jsonGenerator.writeString(Strings.EMPTY);
             return;
         }
 
-        jsonGenerator.writeString(posterPath.replace(imageUrl + "/" + imageSize, ""));
+        if (posterPath.equals(notFoundImageURL)) {
+            jsonGenerator.writeString(Strings.EMPTY);
+            return;
+        }
+
+        jsonGenerator.writeString(posterPath.replace(imageURL + "/" + imageSize, Strings.EMPTY));
     }
 }

--- a/src/main/resources/application-tmdb.yml
+++ b/src/main/resources/application-tmdb.yml
@@ -4,6 +4,7 @@ tmdb:
   image:
     size: original
     url: https://image.tmdb.org/t/p
+    not-found: https://www.themoviedb.org/assets/2/v4/glyphicons/basic/glyphicons-basic-38-picture-grey-c2ebdbb057f2a7614185931650f8cee23fa137b93812ccb132b9df511df1cfac.svg
   uri:
     search:
       multi: /search/multi

--- a/src/test/java/net/ow/move/tmdb/deserializer/ImagePathDeserializerTest.java
+++ b/src/test/java/net/ow/move/tmdb/deserializer/ImagePathDeserializerTest.java
@@ -23,14 +23,17 @@ class ImagePathDeserializerTest {
 
     @Mock private DeserializationContext deserializationContext;
 
-    private final String imageUrl = "http://image.tmdb.org/t/p";
+    private final String imageURL = "http://image.tmdb.org/t/p";
 
     private final String imageSize = "w500";
 
+    private final String notFoundImagePath = "/not-found-image.jpg";
+
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(imagePathDeserializer, "imageUrl", imageUrl);
+        ReflectionTestUtils.setField(imagePathDeserializer, "imageURL", imageURL);
         ReflectionTestUtils.setField(imagePathDeserializer, "imageSize", imageSize);
+        ReflectionTestUtils.setField(imagePathDeserializer, "notFoundImageURL", notFoundImagePath);
     }
 
     @Test
@@ -39,7 +42,7 @@ class ImagePathDeserializerTest {
         String text = "/example.jpg";
         when(jsonParser.getText()).thenReturn(text);
 
-        String expectedUrl = imageUrl + "/" + imageSize + text;
+        String expectedUrl = imageURL + "/" + imageSize + text;
         String result = imagePathDeserializer.deserialize(jsonParser, deserializationContext);
 
         assertEquals(expectedUrl, result);
@@ -52,7 +55,7 @@ class ImagePathDeserializerTest {
 
         String result = imagePathDeserializer.deserialize(jsonParser, deserializationContext);
 
-        assertEquals("", result);
+        assertEquals(notFoundImagePath, result);
     }
 
     @Test
@@ -62,6 +65,6 @@ class ImagePathDeserializerTest {
 
         String result = imagePathDeserializer.deserialize(jsonParser, deserializationContext);
 
-        assertEquals("", result);
+        assertEquals(notFoundImagePath, result);
     }
 }

--- a/src/test/java/net/ow/move/tmdb/serializer/ImagePathSerializerTest.java
+++ b/src/test/java/net/ow/move/tmdb/serializer/ImagePathSerializerTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import lombok.SneakyThrows;
 import net.ow.movie.tmdb.serializer.ImagePathSerializer;
+import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,13 +23,17 @@ class ImagePathSerializerTest {
 
     @Mock private SerializerProvider serializerProvider;
 
+    private final String notFoundImagePath = "/not-found-image.jpg";
+
     @BeforeEach
     void setUp() {
-        final String imageUrl = "http://image.tmdb.org/t/p";
-        ReflectionTestUtils.setField(imagePathSerializer, "imageUrl", imageUrl);
+        String imageURL = "http://image.tmdb.org/t/p";
+        ReflectionTestUtils.setField(imagePathSerializer, "imageURL", imageURL);
 
-        final String imageSize = "w500";
+        String imageSize = "w500";
         ReflectionTestUtils.setField(imagePathSerializer, "imageSize", imageSize);
+
+        ReflectionTestUtils.setField(imagePathSerializer, "notFoundImageURL", notFoundImagePath);
     }
 
     @Test
@@ -43,14 +48,21 @@ class ImagePathSerializerTest {
     @SneakyThrows
     void serializeTest_whenNullPosterPath_thenWritesEmptyString() {
         imagePathSerializer.serialize(null, jsonGenerator, serializerProvider);
-        verify(jsonGenerator).writeString("");
+        verify(jsonGenerator).writeString(Strings.EMPTY);
     }
 
     @Test
     @SneakyThrows
     void serializeTest_whenBlankPosterPath_thenWritesEmptyString() {
         imagePathSerializer.serialize("   ", jsonGenerator, serializerProvider);
-        verify(jsonGenerator).writeString("");
+        verify(jsonGenerator).writeString(Strings.EMPTY);
+    }
+
+    @Test
+    @SneakyThrows
+    void serializeTest_whenIsNotFoundImagePath_thenWritesEmptyString() {
+        imagePathSerializer.serialize(notFoundImagePath, jsonGenerator, serializerProvider);
+        verify(jsonGenerator).writeString(Strings.EMPTY);
     }
 
     @Test


### PR DESCRIPTION
## Description

- Refactor `ImagePathDeserializer` to return `tmdb not found image path` when the image path is `null` or `empty`
- Refactor `ImagePathSerializer` to return `empty string` when image paht is `tmdb not foumd image path`

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

