### PR TITLE
[FIX] Fix null value hanlding for ImagePathDeserializer

### DIFF
--- a/src/main/java/net/ow/movie/tmdb/deserializer/ImagePathDeserializer.java
+++ b/src/main/java/net/ow/movie/tmdb/deserializer/ImagePathDeserializer.java
@@ -20,10 +20,16 @@ public class ImagePathDeserializer extends JsonDeserializer<String> {
     public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException {
         String text = jsonParser.getText();
+
         if (null == text || text.isBlank()) {
             return notFoundImageURL;
         }
 
         return imageURL + "/" + imageSize + text;
+    }
+
+    @Override
+    public String getNullValue(DeserializationContext ctxt) {
+        return notFoundImageURL;
     }
 }

--- a/src/test/java/net/ow/move/tmdb/deserializer/ImagePathDeserializerTest.java
+++ b/src/test/java/net/ow/move/tmdb/deserializer/ImagePathDeserializerTest.java
@@ -67,4 +67,11 @@ class ImagePathDeserializerTest {
 
         assertEquals(notFoundImagePath, result);
     }
+
+    @Test
+    void getNullValueTest_OK() {
+        DeserializationContext context = null;
+        String result = imagePathDeserializer.getNullValue(context);
+        assertEquals(notFoundImagePath, result);
+    }
 }


### PR DESCRIPTION
## Description

- Fix null value hanlding for ImagePathDeserializer to return `tmdb not found image` when image path is `null`

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console

